### PR TITLE
fixing queue_name precedence: config -> DSN -> default

### DIFF
--- a/Tests/Transport/ConnectionTest.php
+++ b/Tests/Transport/ConnectionTest.php
@@ -77,8 +77,21 @@ class ConnectionTest extends TestCase
     {
         $httpClient = $this->createMock(HttpClientInterface::class);
         $this->assertEquals(
-            new Connection(['queue_name' => 'queue_dsn'], new SqsClient(['region' => 'us-east-2', 'accessKeyId' => 'key_dsn', 'accessKeySecret' => 'secret_dsn'], null, $httpClient)),
+            new Connection(['queue_name' => 'queue_options'], new SqsClient(['region' => 'us-east-2', 'accessKeyId' => 'key_dsn', 'accessKeySecret' => 'secret_dsn'], null, $httpClient)),
             Connection::fromDsn('sqs://key_dsn:secret_dsn@default/queue_dsn?region=us-east-2', ['region' => 'eu-west-3', 'queue_name' => 'queue_options', 'access_key' => 'key_option', 'secret_key' => 'secret_option'], $httpClient)
+        );
+    }
+
+    public function testQueueNameDefault()
+    {
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $this->assertEquals(
+            new Connection(['queue_name' => 'messages'], new SqsClient(['region' => 'us-east-2', 'accessKeyId' => 'key_dsn', 'accessKeySecret' => 'secret_dsn'], null, $httpClient)),
+            Connection::fromDsn(
+              'sqs://key_dsn:secret_dsn@default/?region=us-east-2',
+              ['region' => 'eu-west-3', 'access_key' => 'key_option', 'secret_key' => 'secret_option'],
+              $httpClient
+          )
         );
     }
 
@@ -165,7 +178,7 @@ class ConnectionTest extends TestCase
 
         $this->assertEquals(
             new Connection(['queue_name' => 'queue'], new SqsClient(['region' => 'eu-west-1', 'accessKeyId' => null, 'accessKeySecret' => null], null, $httpClient)),
-            Connection::fromDsn('sqs://default/queue', ['queue_name' => 'queue_ignored'], $httpClient)
+            Connection::fromDsn('sqs://default/queue_ignored', ['queue_name' => 'queue'], $httpClient)
         );
     }
 
@@ -342,7 +355,8 @@ class ConnectionTest extends TestCase
 
     private function getMockedQueueUrlResponse(): MockResponse
     {
-        return new MockResponse(<<<XML
+        return new MockResponse(
+            <<<XML
 <GetQueueUrlResponse>
     <GetQueueUrlResult>
         <QueueUrl>https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue</QueueUrl>
@@ -357,7 +371,8 @@ XML
 
     private function getMockedReceiveMessageResponse(): MockResponse
     {
-        return new MockResponse(<<<XML
+        return new MockResponse(
+            <<<XML
 <ReceiveMessageResponse>
   <ReceiveMessageResult>
     <Message>

--- a/Transport/Connection.php
+++ b/Transport/Connection.php
@@ -128,6 +128,11 @@ class Connection
             throw new InvalidArgumentException(sprintf('Unknown option found in DSN: [%s]. Allowed options are [%s].', implode(', ', $queryExtraKeys), implode(', ', array_keys(self::DEFAULT_OPTIONS))));
         }
 
+        $parsedPath = explode('/', ltrim($parsedUrl['path'] ?? '/', '/'));
+        if (\count($parsedPath) > 0 && !empty($queueName = end($parsedPath)) && empty($options['queue_name'])) {
+            $options['queue_name'] = $queueName;
+        }
+
         $options = $query + $options + self::DEFAULT_OPTIONS;
         $configuration = [
             'buffer_size' => (int) $options['buffer_size'],
@@ -157,10 +162,6 @@ class Connection
             $clientConfiguration['endpoint'] = $options['endpoint'];
         }
 
-        $parsedPath = explode('/', ltrim($parsedUrl['path'] ?? '/', '/'));
-        if (\count($parsedPath) > 0 && !empty($queueName = end($parsedPath))) {
-            $configuration['queue_name'] = $queueName;
-        }
         $configuration['account'] = 2 === \count($parsedPath) ? $parsedPath[0] : $options['account'] ?? self::DEFAULT_OPTIONS['account'];
 
         // When the DNS looks like a QueueUrl, we can directly inject it in the connection


### PR DESCRIPTION
This fixes https://github.com/symfony/symfony/issues/44254 , but the precedence has been changed in the tests. Currently it's taking the DSN over the one from config. Suggesting changing the precedence to: `config -> DSN -> default ("messages")`