### PR TITLE
feat: Add a dedicated middleware to create FifoStamp easily

### DIFF
--- a/Middleware/AddFifoStamp.php
+++ b/Middleware/AddFifoStamp.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Middleware;
+
+use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsFifoStamp;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+
+final class AddFifoStamp implements MiddlewareInterface
+{
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        $message = $envelope->getMessage();
+        $messageGroupId = null;
+        $messageDeduplicationId = null;
+
+        if ($message instanceof WithMessageGroupId) {
+            $messageGroupId = $message->messageGroupId();
+        }
+        if ($message instanceof WithMessageDeduplicationId) {
+            $messageDeduplicationId = $message->messageDeduplicationId();
+        }
+
+        if (null !== $messageGroupId || null !== $messageDeduplicationId) {
+            $envelope = $envelope->with(
+                new AmazonSqsFifoStamp(
+                    $messageGroupId,
+                    $messageDeduplicationId,
+                )
+            );
+        }
+
+        return $stack->next()->handle($envelope, $stack);
+    }
+}

--- a/Middleware/WithMessageDeduplicationId.php
+++ b/Middleware/WithMessageDeduplicationId.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Middleware;
+
+interface WithMessageDeduplicationId
+{
+    /**
+     * Max length of the messageDeduplicationId is 128 characters.
+     * Can contain only alphanumeric characters and punctuation.
+     * @See https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html
+     */
+    public function messageDeduplicationId(): string;
+}

--- a/Middleware/WithMessageGroupId.php
+++ b/Middleware/WithMessageGroupId.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Middleware;
+
+interface WithMessageGroupId
+{
+    public function messageGroupId(): string;
+}

--- a/Tests/Middleware/AddFifoStampTest.php
+++ b/Tests/Middleware/AddFifoStampTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Tests\Middleware;
+
+use Symfony\Component\Messenger\Bridge\AmazonSqs\Middleware\AddFifoStamp;
+use Symfony\Component\Messenger\Bridge\AmazonSqs\Middleware\WithMessageDeduplicationId;
+use Symfony\Component\Messenger\Bridge\AmazonSqs\Middleware\WithMessageGroupId;
+use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsFifoStamp;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
+
+class AddFifoStampTest extends MiddlewareTestCase
+{
+    public function testAddStampWithGroupIdOnly(): void
+    {
+        $middleware = new AddFifoStamp();
+        $envelope = new Envelope(new WithMessageGroupIdMessage('groupId'));
+        $finalEnvelope = $middleware->handle($envelope, $this->getStackMock());
+        $stamp = $finalEnvelope->last(AmazonSqsFifoStamp::class);
+        $this->assertNotNull($stamp);
+        /** @var AmazonSqsFifoStamp $stamp */
+        $this->assertEquals('groupId', $stamp->getMessageGroupId());
+        $this->assertNull($stamp->getMessageDeduplicationId());
+    }
+
+    public function testHandleWithDeduplicationIdOnly(): void
+    {
+        $middleware = new AddFifoStamp();
+        $envelope = new Envelope(new WithMessageDeduplicationIdMessage('deduplicationId'));
+        $finalEnvelope = $middleware->handle($envelope, $this->getStackMock());
+        $stamp = $finalEnvelope->last(AmazonSqsFifoStamp::class);
+        $this->assertNotNull($stamp);
+        /** @var AmazonSqsFifoStamp $stamp */
+        $this->assertEquals('deduplicationId', $stamp->getMessageDeduplicationId());
+        $this->assertNull($stamp->getMessageGroupId());
+    }
+
+    public function testHandleWithGroupIdAndDeduplicationId(): void
+    {
+        $middleware = new AddFifoStamp();
+        $envelope = new Envelope(new WithMessageDeduplicationIdAndMessageGroupIdMessage('my_group', 'my_random_id'));
+        $finalEnvelope = $middleware->handle($envelope, $this->getStackMock());
+        $stamp = $finalEnvelope->last(AmazonSqsFifoStamp::class);
+        $this->assertNotNull($stamp);
+        /** @var AmazonSqsFifoStamp $stamp */
+        $this->assertEquals('my_random_id', $stamp->getMessageDeduplicationId());
+        $this->assertEquals('my_group', $stamp->getMessageGroupId());
+    }
+
+    public function testHandleWithoutId(): void
+    {
+        $middleware = new AddFifoStamp();
+        $envelope = new Envelope(new WithoutIdMessage());
+        $finalEnvelope = $middleware->handle($envelope, $this->getStackMock());
+        $stamp = $finalEnvelope->last(AmazonSqsFifoStamp::class);
+        /** @var AmazonSqsFifoStamp $stamp */
+        $this->assertNull($stamp);
+    }
+}
+
+class WithMessageDeduplicationIdAndMessageGroupIdMessage implements WithMessageDeduplicationId, WithMessageGroupId
+{
+    private string $messageGroupId;
+    private string $messageDeduplicationId;
+
+    public function __construct(
+        string $messageGroupId,
+        string $messageDeduplicationId
+    )
+    {
+        $this->messageGroupId = $messageGroupId;
+        $this->messageDeduplicationId = $messageDeduplicationId;
+    }
+
+    public function messageDeduplicationId(): string
+    {
+        return $this->messageDeduplicationId;
+    }
+
+    public function messageGroupId(): string
+    {
+        return $this->messageGroupId;
+    }
+}
+
+
+class WithMessageDeduplicationIdMessage implements WithMessageDeduplicationId
+{
+    private string $messageDeduplicationId;
+
+    public function __construct(
+        string $messageDeduplicationId
+    )
+    {
+        $this->messageDeduplicationId = $messageDeduplicationId;
+    }
+
+    public function messageDeduplicationId(): string
+    {
+        return $this->messageDeduplicationId;
+    }
+}
+
+
+class WithMessageGroupIdMessage implements WithMessageGroupId
+{
+    private string $messageGroupId;
+
+    public function __construct(
+        string $messageGroupId
+    )
+    {
+        $this->messageGroupId = $messageGroupId;
+    }
+
+    public function messageGroupId(): string
+    {
+        return $this->messageGroupId;
+    }
+}
+class WithoutIdMessage
+{
+}


### PR DESCRIPTION
Currently it is not very easy to use fifo stamp as you need to go down to the envelope when you often handle only message in your app.

We also think that the message should be responsible to choose its own groupId.

So we come with this very simple middleware and 2 interfaces. We use it in our own system since 3 months.

It allows to keep messenger concept outside our messages while continuing to benefit from it.