### PR TITLE
[Messenger][AmazonSqs] Do not override queue-level DelaySeconds when no DelayStamp is set

### DIFF
--- a/Tests/Transport/AmazonSqsSenderTest.php
+++ b/Tests/Transport/AmazonSqsSenderTest.php
@@ -46,7 +46,7 @@ class AmazonSqsSenderTest extends TestCase
 
         $connection = $this->createMock(Connection::class);
         $connection->expects($this->once())->method('send')
-            ->with($encoded['body'], $encoded['headers'], 0, $stamp->getMessageGroupId(), $stamp->getMessageDeduplicationId());
+            ->with($encoded['body'], $encoded['headers'], null, $stamp->getMessageGroupId(), $stamp->getMessageDeduplicationId());
 
         $serializer = $this->createMock(SerializerInterface::class);
         $serializer->expects($this->once())->method('encode')->with($envelope)->willReturn($encoded);
@@ -64,7 +64,7 @@ class AmazonSqsSenderTest extends TestCase
 
         $connection = $this->createMock(Connection::class);
         $connection->expects($this->once())->method('send')
-            ->with($encoded['body'], $encoded['headers'], 0, null, null, $stamp->getTraceId());
+            ->with($encoded['body'], $encoded['headers'], null, null, null, $stamp->getTraceId());
 
         $serializer = $this->createMock(SerializerInterface::class);
         $serializer->expects($this->once())->method('encode')->with($envelope)->willReturn($encoded);

--- a/Transport/AmazonSqsSender.php
+++ b/Transport/AmazonSqsSender.php
@@ -36,7 +36,7 @@ class AmazonSqsSender implements SenderInterface
 
         /** @var DelayStamp|null $delayStamp */
         $delayStamp = $envelope->last(DelayStamp::class);
-        $delay = null !== $delayStamp ? (int) ceil($delayStamp->getDelay() / 1000) : 0;
+        $delay = null !== $delayStamp ? (int) ceil($delayStamp->getDelay() / 1000) : null;
 
         $messageGroupId = null;
         $messageDeduplicationId = null;

--- a/Transport/Connection.php
+++ b/Transport/Connection.php
@@ -357,7 +357,7 @@ class Connection
         return (int) ($attributes[QueueAttributeName::APPROXIMATE_NUMBER_OF_MESSAGES] ?? 0);
     }
 
-    public function send(string $body, array $headers, int $delay = 0, ?string $messageGroupId = null, ?string $messageDeduplicationId = null, ?string $xrayTraceId = null): void
+    public function send(string $body, array $headers, ?int $delay = null, ?string $messageGroupId = null, ?string $messageDeduplicationId = null, ?string $xrayTraceId = null): void
     {
         if ($this->configuration['auto_setup']) {
             $this->setup();
@@ -366,11 +366,14 @@ class Connection
         $parameters = [
             'QueueUrl' => $this->getQueueUrl(),
             'MessageBody' => $body,
-            // Maximum delay is 15 minutes. See https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-timers.html.
-            'DelaySeconds' => min(900, $delay),
             'MessageAttributes' => [],
             'MessageSystemAttributes' => [],
         ];
+
+        if (null !== $delay) {
+            // Maximum delay is 15 minutes. See https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-timers.html.
+            $parameters['DelaySeconds'] = min(900, $delay);
+        }
 
         $specialHeaders = [];
         foreach ($headers as $name => $value) {


### PR DESCRIPTION
## Problem

When sending a message without a `DelayStamp`, the SQS transport explicitly sets `DelaySeconds: 0` on the `SendMessage` API call. This **overrides** any queue-level `DelaySeconds` configured in the SQS queue infrastructure (e.g. via Terraform/CloudFormation).

The SQS API behavior is: if `DelaySeconds` is included in a `SendMessage` call, it takes precedence over the queue's default delivery delay. By always sending `DelaySeconds: 0`, the transport makes it impossible to rely on queue-level delay configuration.

## Real-world impact

In our case, we dispatch messages from a Doctrine `postPersist` lifecycle callback. The message is sent to SQS **before the database transaction commits**. We configured a 15-second `DelaySeconds` on the SQS queue to give the transaction time to commit before the consumer processes the message. But the transport was silently overriding it to 0, causing the consumer to always fail on first attempt (entity not found), then succeed on SQS retry ~70s later.

## Fix

- `AmazonSqsSender`: pass `null` instead of `0` when no `DelayStamp` is present
- `Connection::send()`: only include `DelaySeconds` in the SQS API parameters when explicitly set (`null` = use queue default)

This is fully backward-compatible: messages with an explicit `DelayStamp(0)` still send `DelaySeconds: 0`. Only the "no stamp" case changes — from overriding the queue default to respecting it.